### PR TITLE
Add trimming of attribute names and values in GFF3

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -82,13 +82,14 @@ export function parseAttributes(attrString) {
       const nv = a.split('=', 2)
       if (!(nv[1] && nv[1].length)) return
 
-      let arec = attrs[nv[0]]
+      nv[0] = nv[0].trim()
+      let arec = attrs[nv[0].trim()]
       if (!arec) {
         arec = []
         attrs[nv[0]] = arec
       }
 
-      arec.push(...nv[1].split(',').map(unescape))
+      arec.push(...nv[1].split(',').map(s => s.trim()).map(unescape))
     })
   return attrs
 }

--- a/test/data/knownGene_out_of_order.gff3
+++ b/test/data/knownGene_out_of_order.gff3
@@ -1,6 +1,6 @@
 ##gff-version 3
 chr17	UCSC	CDS	62468039	62468236	.	-	1	Parent=A00469
-chr17	UCSC	fakething	1	500	.	-	2	Derives_from=A00469;Parent=AB000114,A00469;Note=crazy multi-parent out-of-order thing, also including a Derives_from
+chr17	UCSC	fakething	1	500	.	-	2	Derives_from=A00469;Parent=AB000114,A00469;Note=crazy multi-parent out-of-order thing%2C also including a Derives_from
 chr17	UCSC	CDS	62468490	62468654	.	-	2	Parent=A00469
 chr17	UCSC	mRNA	62467934	62469545	.	-	.	ID=A00469;Dbxref=AFFX-U133:205840_x_at,Locuslink:2688,Genbank-mRNA:A00469,Swissprot:P01241,PFAM:PF00103,AFFX-U95:1332_f_at,Swissprot:SOMA_HUMAN;Note=growth%20hormone%201;Alias=GH1
 chr17	UCSC	three_prime_UTR	62467934	62468038	.	-	.	Parent=A00469
@@ -14,7 +14,7 @@ chr30	UCSC	mRNA	11234	45664	.	-	.	ID=AB000114;Note=guess what this thing has ano
 chr9	UCSC	three_prime_UTR	90517946	90518841	.	-	.	Parent=AB000114
 chr9	UCSC	CDS	90518842	90519167	.	-	1	Parent=AB000114
 chr9	UCSC	CDS	90520309	90521248	.	-	0	Parent=AB000114
-chr17	UCSC	otherfakething	1	500	.	-	2	Derives_from=A00469;Parent=AB000114,A00469;Note=crazy multi-parent thing, but this time coming after its parents
+chr17	UCSC	otherfakething	1	500	.	-	2	Derives_from=A00469;Parent=AB000114,A00469;Note=crazy multi-parent thing%2C but this time coming after its parents
 chr9	UCSC	five_prime_UTR	90521249	90521264	.	-	.	Parent=AB000114
 chr9	UCSC	five_prime_UTR	90527892	90527968	.	-	.	Parent=AB000114
 ###

--- a/test/data/knownGene_out_of_order.result.json
+++ b/test/data/knownGene_out_of_order.result.json
@@ -75,8 +75,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent out-of-order thing",
-                " also including a Derives_from"
+                "crazy multi-parent out-of-order thing, also including a Derives_from"
               ]
             },
             "child_features": [],
@@ -216,8 +215,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent thing",
-                " but this time coming after its parents"
+                "crazy multi-parent thing, but this time coming after its parents"
               ]
             },
             "child_features": [],
@@ -245,8 +243,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent out-of-order thing",
-                " also including a Derives_from"
+                "crazy multi-parent out-of-order thing, also including a Derives_from"
               ]
             },
             "child_features": [],
@@ -272,8 +269,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent thing",
-                " but this time coming after its parents"
+                "crazy multi-parent thing, but this time coming after its parents"
               ]
             },
             "child_features": [],
@@ -343,8 +339,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent out-of-order thing",
-                " also including a Derives_from"
+                "crazy multi-parent out-of-order thing, also including a Derives_from"
               ]
             },
             "child_features": [],
@@ -427,8 +422,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent thing",
-                " but this time coming after its parents"
+                "crazy multi-parent thing, but this time coming after its parents"
               ]
             },
             "child_features": [],
@@ -570,8 +564,7 @@
                 "A00469"
               ],
               "Note": [
-                "crazy multi-parent thing",
-                " but this time coming after its parents"
+                "crazy multi-parent thing, but this time coming after its parents"
               ]
             },
             "child_features": [],

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -153,6 +153,40 @@ describe('GFF3 parser', () => {
     expect(result).toEqual(referenceResult)
   })
 
+  it('can parse some whitespace', () => {
+    const gff3 = `
+SL2.40%25ch01	IT%25AG eugene	g%25e;ne	80999140	81004317	.	+	.	 multivalue = val1,val2, val3;testing = blah
+`
+
+    const result = gff.parseStringSync(gff3, {
+      parseFeatures: true,
+      parseDirectives: true,
+      parseComments: true,
+    })
+    expect(result).toHaveLength(1)
+    const referenceResult = [
+      [
+        {
+          seq_id: 'SL2.40%ch01',
+          source: 'IT%AG eugene',
+          type: 'g%e;ne',
+          start: 80999140,
+          end: 81004317,
+          score: null,
+          strand: '+',
+          phase: null,
+          attributes: {
+            multivalue: ['val1', 'val2', 'val3'],
+            testing: ['blah']
+          },
+          child_features: [],
+          derived_features: [],
+        },
+      ],
+    ]
+
+    expect(result).toEqual(referenceResult)
+  })
   it('can parse another string synchronously', () => {
     const gff3 = `
 SL2.40%25ch01	IT%25AG eugene	g%25e;ne	80999140	81004317	.	+	.	Alias=Solyc01g098840;ID=gene:Solyc01g098840.2;Name=Solyc01g098840.2;from_BOGAS=1;length=5178


### PR DESCRIPTION
Follow up to the JBrowse flatfile-to-json.pl PR to trim whitespace surrounding GFF3 attribute keys and values