### PR TITLE
Try to not throw on weird sequence-region line

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -142,8 +142,8 @@ export function parseDirective(line) {
   if (name === 'sequence-region') {
     const c = contents.split(/\s+/, 3)
     parsed.seq_id = c[0]
-    parsed.start = c[1].replace(/\D/g, '')
-    parsed.end = c[2].replace(/\D/g, '')
+    parsed.start = c[1] && c[1].replace(/\D/g, '')
+    parsed.end = c[2] && c[2].replace(/\D/g, '')
   } else if (name === 'genome-build') {
     ;[parsed.source, parsed.buildname] = contents.split(/\s+/, 2)
   }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,11 +1,22 @@
 import gff from '../src'
 
-const { parseAttributes, parseFeature, formatFeature, escapeColumn } = gff.util
+const {
+  parseAttributes,
+  parseFeature,
+  parseDirective,
+  formatFeature,
+  escapeColumn,
+} = gff.util
 
 describe('GFF3 utils', () => {
   it('can escape properly', () => {
     expect(gff.util.escape(5)).toEqual('5')
     // TODO: should add more escape tests
+  })
+  it('can parse a bad directive', () => {
+    expect(() => {
+      parseDirective('##sequence-region no_start_end_on_sequence_region')
+    }).not.toThrow()
   })
   it('can unescape properly', () => {
     expect(gff.util.unescape(' ')).toEqual(' ')


### PR DESCRIPTION
This avoids throwing on a sequence-region directive that didn't parse correctly

Potentially that puts the onus on the downstream app to handle existence of undefineds if it is trying to use the sequence-region directives, but also considering the common app not really caring about sequence-region, I think this is ok

Seen here https://github.com/GMOD/docker-apollo/issues/47