### PR TITLE
Remove Derives_from strictness

### DIFF
--- a/test/data/tair10.gff3
+++ b/test/data/tair10.gff3
@@ -1,4 +1,4 @@
-1	TAIR10	chromosome      1	30427671	.	.	.	ID=Chr1;Name=Chr1
+1	TAIR10	chromosome	1	30427671	.	.	.	ID=Chr1;Name=Chr1
 1	TAIR10	gene	3631	5899	.	+	.	ID=AT1G01010;Note=protein_coding_gene;Name=AT1G01010
 1	TAIR10	mRNA	3631	5899	.	+	.	ID=AT1G01010.1;Parent=AT1G01010;Name=AT1G01010.1;Index=1
 1	TAIR10	protein	3760	5630	.	+	.	ID=AT1G01010.1-Protein;Name=AT1G01010.1;Derives_from=AT1G01010.1

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -129,7 +129,7 @@ describe('GFF3 parser', () => {
     expect(mrnaLines[2].child_features).toHaveLength(6)
 
     const referenceResult = JSON.parse(
-      fs.readFileSync('./data/spec_eden.result.json', 'utf8'),
+      fs.readFileSync(require.resolve('./data/spec_eden.result.json'), 'utf8'),
     )
     expect(stuff.all).toEqual(referenceResult)
   })
@@ -140,16 +140,15 @@ describe('GFF3 parser', () => {
     expect(stuff.all).toHaveLength(2)
   })
 
-  xit('can parse an excerpt of the TAIR10 gff3', async () => {
+  it('can parse an excerpt of the TAIR10 gff3', async () => {
     const stuff = await readAll('./data/tair10.gff3')
-    console.log(stuff.all)
     expect(stuff.all).toHaveLength(3)
   })
 
-  it('can parse full TAIR10 gff3', async () => {
-    const stuff = await readAll('./data/tair10_full.gff')
-    console.log({ stuff })
-  }, 1500000)
+  it('can parse chr1 TAIR10 gff3', async () => {
+    const stuff = await readAll('./data/tair10_chr1.gff')
+    expect(stuff.all).toHaveLength(8434)
+  })
 
   // check that some files throw a parse error
   ;['mm9_sample_ensembl.gff3', 'Saccharomyces_cerevisiae_EF3_e64.gff3'].forEach(

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -129,7 +129,7 @@ describe('GFF3 parser', () => {
     expect(mrnaLines[2].child_features).toHaveLength(6)
 
     const referenceResult = JSON.parse(
-      fs.readFileSync(require.resolve('./data/spec_eden.result.json'), 'utf8'),
+      fs.readFileSync('./data/spec_eden.result.json', 'utf8'),
     )
     expect(stuff.all).toEqual(referenceResult)
   })
@@ -140,11 +140,16 @@ describe('GFF3 parser', () => {
     expect(stuff.all).toHaveLength(2)
   })
 
-  it('can parse an excerpt of the TAIR10 gff3', async () => {
+  xit('can parse an excerpt of the TAIR10 gff3', async () => {
     const stuff = await readAll('./data/tair10.gff3')
-    expect(true).toBeTruthy()
+    console.log(stuff.all)
     expect(stuff.all).toHaveLength(3)
   })
+
+  it('can parse full TAIR10 gff3', async () => {
+    const stuff = await readAll('./data/tair10_full.gff')
+    console.log({ stuff })
+  }, 1500000)
 
   // check that some files throw a parse error
   ;['mm9_sample_ensembl.gff3', 'Saccharomyces_cerevisiae_EF3_e64.gff3'].forEach(


### PR DESCRIPTION
This PR tracks derives_from orphans separately from parent relationship orphans

This PR also outputs derived_from orphans as separate features. this appears to match the spirit of the TAIR gff, which their "transposable element derived genes" in the TAIR gff would otherwise be hidden


fixes #4 

not sure precisely how this meshes with the gff specification, derives from is used in different context there e.g. for the polycistronic gene https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md which is the canonical derives from

just as background, a polycistronic transcript basically encodes multiple genes from a single transcript e.g.  the mRNA transcript is cut up into pieces that encode separate protein products