### PR TITLE
Allow disabling derives from references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.log
 .vscode/
 esm
+.eslintcache

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,6 +26,8 @@ export type {
 
 /** Parser options */
 export interface ParseOptions {
+  /** Whether to resolve references to derives from features */
+  disableDerivesFromReferences?: boolean
   /** Text encoding of the input GFF3. default 'utf8' */
   encoding?: BufferEncoding
   /** Whether to parse features, default true */
@@ -63,6 +65,7 @@ function _processParseOptions(options: ParseOptions): ParseOptionsProcessed {
     parseSequences: true,
     parseComments: false,
     bufferSize: 1000,
+    disableDerivesFromReferences: false,
     ...options,
   }
 
@@ -98,6 +101,7 @@ class GFFTransform extends Transform {
       sequenceCallback: options.parseSequences ? push : undefined,
       errorCallback: (err) => this.emit('error', err),
       bufferSize: options.bufferSize,
+      disableDerivesFromReferences: options.disableDerivesFromReferences,
     })
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -466,6 +466,7 @@ export function parseStringSync(
     directiveCallback: options.parseDirectives ? push : undefined,
     commentCallback: options.parseComments ? push : undefined,
     sequenceCallback: options.parseSequences ? push : undefined,
+    disableDerivesFromReferences: options.disableDerivesFromReferences || false,
     bufferSize: Infinity,
     errorCallback: (err) => {
       throw err

--- a/test/data/tair10.gff3
+++ b/test/data/tair10.gff3
@@ -1,4 +1,4 @@
-1	TAIR10	chromosome      1	30427671	.	.	.	ID=Chr1;Name=Chr1
+1	TAIR10	chromosome	1	30427671	.	.	.	ID=Chr1;Name=Chr1
 1	TAIR10	gene	3631	5899	.	+	.	ID=AT1G01010;Note=protein_coding_gene;Name=AT1G01010
 1	TAIR10	mRNA	3631	5899	.	+	.	ID=AT1G01010.1;Parent=AT1G01010;Name=AT1G01010.1;Index=1
 1	TAIR10	protein	3760	5630	.	+	.	ID=AT1G01010.1-Protein;Name=AT1G01010.1;Derives_from=AT1G01010.1

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -16,7 +16,10 @@ interface ReadAllResults {
   all: (GFF3Feature | GFF3Comment | GFF3Directive | GFF3Sequence)[]
 }
 
-function readAll(filename: string): Promise<ReadAllResults> {
+function readAll(
+  filename: string,
+  args: Record<string, unknown> = {},
+): Promise<ReadAllResults> {
   return new Promise((resolve, reject) => {
     const stuff: ReadAllResults = {
       features: [],
@@ -35,6 +38,7 @@ function readAll(filename: string): Promise<ReadAllResults> {
           parseComments: true,
           parseSequences: true,
           bufferSize: 10,
+          ...args,
         }),
       )
       .on('data', (d) => {
@@ -142,8 +146,14 @@ describe('GFF3 parser', () => {
 
   it('can parse an excerpt of the TAIR10 gff3', async () => {
     const stuff = await readAll('./data/tair10.gff3')
-    expect(true).toBeTruthy()
     expect(stuff.all).toHaveLength(3)
+  })
+
+  it('can parse chr1 TAIR10 gff3', async () => {
+    const stuff = await readAll('./data/tair10_chr1.gff', {
+      disableDerivesFromReferences: true,
+    })
+    expect(stuff.all).toHaveLength(17697)
   })
 
   // check that some files throw a parse error


### PR DESCRIPTION
This option allows fully disabling derives from reference resolving. This is an alternative to https://github.com/GMOD/gff-js/pull/56 that just disables the resolution of Derives_from entries

I would probably suggest turning it on by default in jbrowse 2